### PR TITLE
Adding TSTP to the list of signals sent to clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea/

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Start pool with a non-default path config
 
 ## Signals
 
-Signals `USR1`, `USR2` are forwarded to the children.
+Signals `USR1`, `USR2`, and `TSTP` are forwarded to the children. Depending on the version of Sidekiq, you may need to send `USR1` or `TSTP` to prepare it for shutdown. For more information, please read [signals and sidekiq](https://github.com/mperham/sidekiq/wiki/Signals) documentation.
 
 Signal `HUP` to parent starts new children and then stops old.
 

--- a/lib/sidekiq/pool/cli.rb
+++ b/lib/sidekiq/pool/cli.rb
@@ -241,7 +241,7 @@ module Sidekiq
           exit(0)
         when 'CHLD'
           check_pool
-        when 'USR1'
+        when 'USR1', 'TSTP'
           @done = true
           update_process_name
           signal_to_pool(sig)


### PR DESCRIPTION
Starting with Sidekiq version 5, TSTP, not USR1 is the signal that needs to be sent to the children to notify them about impeding shutdown.

Also adding .idea/ folder used by RubyMine to the list of git-ignored files.