### PR TITLE
Introduce SimpleCov for test coverage, and CodeClimate for the rest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - ruby-head
   - 2.5.1
@@ -6,9 +7,21 @@ rvm:
   - 2.3.4
   - 2.2.7
 before_install: gem install bundler -v 1.11.2
+before_script:
+  - gem install bundler -v 1.11.2
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+script:
+  - bundle exec rspec
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 after_success:
 - >
   [ "${TRAVIS_PULL_REQUEST}" != "false" ] &&
   [ "${TRAVIS_RUBY_VERSION}" = "2.5.1" ] &&
     PRONTO_PULL_REQUEST_ID=${TRAVIS_PULL_REQUEST} \
       bundle exec pronto run -f github_status github_pr -c origin/${TRAVIS_BRANCH}
+env:
+  global:
+    secure: JExKDpE3tE8z7o3soZeXRiB8CRyz9EjMplG/fJTNf2CDePEeiPxiXIo4yXH0aCqkBh4dLTXdGpMd0ezRHdeCwcxQslBwRpyMJlPCdwpw95lqSX4Jqafol+qQ1MJwhri12U8+msYdLkUQ6mhcRAdM3kmASu4VZ0uBrjcNwbwirsMpOUHO8qrjlYj3p9HkLD3Z2Qp6CkVbyL4XqJsRcvy+s6ozK3MY6LoYzK5LLevmNMDTI+6Qg3GQgpNNb2Aihih7JQwUNyw4h55jEz2uorTk1od1spuyfX8q4UfOxfxqnYVYubgtzAifAmNdichdljHYW30+4MdnX6PCUiY2/ynyLdpmiAKntlp8B9Qh/Qs+g/BYIG1qIWNMvu7YmxWoJI8iHEWe+fC6JpLxo6PLPGCg/1yQ3Af4ZIZNMR5i37hSmp/2LAo+UF2y9nW6lN9x3ToYlGCSrWNuAt1DpXXgPLskIuiLPTwQQ6xVbnraInOInBbumYZwJwsRoFvg4Lh3GVHrOR123pHBcjPD4SQBuNEKAeHizdgbE/1LiNYpj/ecGGN+C9wW2vORohi4LJmEjUpnkLtNeJOSe9NG4OpgtmwkOy6E/8NCjlq0BrcHreVg4LsXmWFh1UFAIB2captJuBsok72QspGSVcjUctFUzC624svperwxOj4TgAjZ/8SOyFs=

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Gem](https://img.shields.io/gem/v/sidekiq-pool.svg)](https://rubygems.org/gems/sidekiq-pool)
 [![Build Status](https://travis-ci.org/vinted/sidekiq-pool.svg?branch=master)](https://travis-ci.org/vinted/sidekiq-pool)
+[![Maintainability](https://api.codeclimate.com/v1/badges/c565c4357b9c525bd2c1/maintainability)](https://codeclimate.com/github/kigster/sidekiq-pool/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/c565c4357b9c525bd2c1/test_coverage)](https://codeclimate.com/github/kigster/sidekiq-pool/test_coverage)
 
 Allows Sidekiq using more CPU cores on Ruby MRI by forking multiple processes.
 Also adds an option to use different command line option workers in the same pool.

--- a/sidekiq-pool.gemspec
+++ b/sidekiq-pool.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pronto-rubocop', '~> 0.9'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'simplecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,10 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'simplecov'
+SimpleCov.start do
+  add_filter '/spec/'
+end
+
 require 'sidekiq/pool'
+
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 $TESTING = true


### PR DESCRIPTION
I've been coding for over thirty years, and I take "code quality" tools with a grain of salt, always. Having said, I also really appreciate knowing how much of the production tools I rely on is covered by the automated tests, and how well the code is maintained, structured, and how easily it can be refactored and fixed if needed. CodeClimate provides information about where the improvements can make the biggest impact. 

I am hoping the authors would enjoy knowing how well the tool is tested, where the hot spots are, and, perhaps, there is an extra motivation to add test coverage to the old or new features, as well as adding a failing test or two to a known bug.

I do appreciate the sentiment that pull requests that contain many unrelated changes often invoke conflicting feelings, as — "why is this person changing so many things"? Right? 

But at the same the time is scarce, and it took me an additional two hours on top of the four I already spent on this gem when I submitted my original PR. Not only that, but I decided to omit a lot of small refactors that made the code more readable and more maintainable. You could say — this is subjective. Great! Let's remove subjective and use tools to tell us if the code quality had been affected. 

So this is what this PR is about. I hope it's merged, and we can start moving towards making `sidekiq-pool` well-tested alternative to [Sidekiq Enterprise](https://sidekiq.org/products/enterprise.html) when it comes to multi-core processing on MRI. I support Mike and everything he's done for the ruby community, but feel very frustrated about the fact that Sidekiq Pro, which costs $999/year, does not include multi-core functionality.

> NOTE: If you accept this PR, you will need to replace the Code Climate test reporter. Open [settings](https://codeclimate.com/github/vinted/sidekiq-pool), click on Test Coverage on the left, copy the token, and then run on the command line: `travis encrypt CC_TEST_REPORTER_ID=XXXXXXXX --add env.global` (after removing my `env.global` from the `.travis.yml`).