### PR TITLE
Overwrite the way we store master pid in pid file

### DIFF
--- a/lib/sidekiq/pool/cli.rb
+++ b/lib/sidekiq/pool/cli.rb
@@ -20,8 +20,13 @@ module Sidekiq
 
       alias_method :run_child, :run
 
+      def write_pid
+        super if @master_pid == ::Process.pid
+      end
+
       def run
         @master_pid = $$
+        write_pid
 
         trap_signals
         update_process_name

--- a/lib/sidekiq/pool/version.rb
+++ b/lib/sidekiq/pool/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Pool
-    VERSION = '1.8.1'
+    VERSION = '1.9.0'
   end
 end


### PR DESCRIPTION
Sidekiq in release 5.2.9, changes the way they store the PID files of the process. It ended up, that we on every fork overwrite this value, for that reason master process checker cannot match the master process PID from the file, and it starts restarting the sidekiq pool, which causes us problems.

This PR will write master process PID only once if it matches the first run master process id.