### PR TITLE
Annotate process with worker id when starting

### DIFF
--- a/lib/sidekiq/pool/cli.rb
+++ b/lib/sidekiq/pool/cli.rb
@@ -208,7 +208,7 @@ module Sidekiq
           options.merge!(opts)
 
           @self_write.close
-          $0 = 'sidekiq starting'
+          $0 = "sidekiq #{Sidekiq::VERSION} worker #{index} starting"
           options[:index] = index
 
           # reset child identity

--- a/lib/sidekiq/pool/version.rb
+++ b/lib/sidekiq/pool/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Pool
-    VERSION = '1.9.1'
+    VERSION = '1.9.2'
   end
 end


### PR DESCRIPTION
Annotate process name with worker id when starting from the beginning.