### PR TITLE
Update CI pipeline

### DIFF
--- a/.github/workflows/build_release_pipeline.yaml
+++ b/.github/workflows/build_release_pipeline.yaml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0', '3.1' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -31,11 +31,11 @@ jobs:
     needs: test
     if: success() && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
           bundler-cache: true
       - name: Setup
         run: | 
@@ -45,7 +45,7 @@ jobs:
         id: build
         run: |
           bundle exec rake build
-          echo "::set-output name=gem_version::v$(bundle exec rake version)"
+          run: echo "GEM_VERSION=v$(bundle exec rake version)" >> $GITHUB_ENV
 
       - name: Release
         if: success() && github.ref == 'refs/heads/master'
@@ -67,6 +67,6 @@ jobs:
             github.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: "refs/tags/${{ steps.build.outputs.gem_version }}",
+              ref: "refs/tags/${{ env.GEM_VERSION }}",
               sha: context.sha
             })

--- a/.github/workflows/build_release_pipeline.yaml
+++ b/.github/workflows/build_release_pipeline.yaml
@@ -36,7 +36,6 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
           bundler-cache: true
       - name: Setup
         run: | 

--- a/.github/workflows/build_release_pipeline.yaml
+++ b/.github/workflows/build_release_pipeline.yaml
@@ -1,10 +1,11 @@
 name: Test, build, and release Ruby gem
 
 on:
-  pull_request: 
-    branches: [ master ]
   push:
-  workflow_dispatch:
+    branches: [master]
+    workflow_dispatch:
+  pull_request: 
+    branches: [master]
 
 jobs:
   test:

--- a/.github/workflows/build_release_pipeline.yaml
+++ b/.github/workflows/build_release_pipeline.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.7', '3.0', '3.1' ]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Ruby


### PR DESCRIPTION
- Update checkout pipeline to v3 - see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- Build from ruby-version ruby version
- Updates set-output commands - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- Fix triggers to not run pull/pr against branch